### PR TITLE
Adds a KTLint Gradle Plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,14 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+	id("com.diffplug.spotless") version "6.15.0"
 	id("org.springframework.boot") version "3.0.2"
 	id("io.spring.dependency-management") version "1.1.0"
 	id("org.jetbrains.dokka") version "1.7.20"
 	kotlin("jvm") version "1.7.22"
 	kotlin("plugin.spring") version "1.7.22"
 	jacoco
+
 }
 
 subprojects {
@@ -16,6 +18,12 @@ subprojects {
 jacoco {
 	toolVersion = "0.8.8"
 	reportsDirectory.set(layout.buildDirectory.dir("$buildDir/jacoco"))
+}
+
+spotless {
+	kotlin {
+		ktlint()
+	}
 }
 
 group = "game.manager.nomic"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,29 +1,28 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	id("com.diffplug.spotless") version "6.15.0"
-	id("org.springframework.boot") version "3.0.2"
-	id("io.spring.dependency-management") version "1.1.0"
-	id("org.jetbrains.dokka") version "1.7.20"
-	kotlin("jvm") version "1.7.22"
-	kotlin("plugin.spring") version "1.7.22"
-	jacoco
-
+    id("com.diffplug.spotless") version "6.15.0"
+    id("org.springframework.boot") version "3.0.2"
+    id("io.spring.dependency-management") version "1.1.0"
+    id("org.jetbrains.dokka") version "1.7.20"
+    kotlin("jvm") version "1.7.22"
+    kotlin("plugin.spring") version "1.7.22"
+    jacoco
 }
 
 subprojects {
-	apply(plugin = "org.jetbrains.dokka")
+    apply(plugin = "org.jetbrains.dokka")
 }
 
 jacoco {
-	toolVersion = "0.8.8"
-	reportsDirectory.set(layout.buildDirectory.dir("$buildDir/jacoco"))
+    toolVersion = "0.8.8"
+    reportsDirectory.set(layout.buildDirectory.dir("$buildDir/jacoco"))
 }
 
 spotless {
-	kotlin {
-		ktlint()
-	}
+    kotlin {
+        ktlint()
+    }
 }
 
 group = "game.manager.nomic"
@@ -31,38 +30,38 @@ version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-web")
-	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-	implementation("mysql:mysql-connector-java:8.0.25")
-	implementation("org.ktorm:ktorm-support-mysql:3.6.0")
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testImplementation("com.h2database:h2")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("mysql:mysql-connector-java:8.0.25")
+    implementation("org.ktorm:ktorm-support-mysql:3.6.0")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("com.h2database:h2")
 }
 
 tasks.withType<KotlinCompile> {
-	kotlinOptions {
-		freeCompilerArgs = listOf("-Xjsr305=strict")
-		jvmTarget = "17"
-	}
+    kotlinOptions {
+        freeCompilerArgs = listOf("-Xjsr305=strict")
+        jvmTarget = "17"
+    }
 }
 
 tasks.withType<Test> {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 tasks.test {
-	finalizedBy(tasks.jacocoTestReport)
+    finalizedBy(tasks.jacocoTestReport)
 }
 
 tasks.jacocoTestReport {
-	dependsOn(tasks.test)
-	reports {
-		xml.required.set(true)
-	}
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ jacoco {
 
 spotless {
     kotlin {
-        ktlint()
+        ktlint("0.46.1") // Same version that CI uses
     }
 }
 


### PR DESCRIPTION
This PR adds a gradle plugin that adds some tasks that can run the same linter as the CI/CD. You can check with `./gradlew spotlessCheck`, and you can autoapply the linter with `./gradlew spotlessApply`.