### PR TITLE
Adds toggle for requiring authentication for development and demo

### DIFF
--- a/src/main/kotlin/nomic/config/security/RoutingSecurityConfig.kt
+++ b/src/main/kotlin/nomic/config/security/RoutingSecurityConfig.kt
@@ -6,7 +6,6 @@ import nomic.domain.auth.ITokenRegistry
 import nomic.domain.auth.IUserAuthenticator
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.env.ConfigurableEnvironment
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
@@ -25,9 +24,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 class RoutingSecurityConfig {
 
     @Bean
-    fun filterChain(http: HttpSecurity, tokenRegistry: ITokenRegistry, userAuthenticator: IUserAuthenticator, environment: ConfigurableEnvironment): SecurityFilterChain {
-        val isAuthOptional = environment.getProperty("auth.optional")?.equals("true") == true
-
+    fun filterChain(http: HttpSecurity, tokenRegistry: ITokenRegistry, userAuthenticator: IUserAuthenticator): SecurityFilterChain {
         val jwtFilter = JWTAuthenticationSecurityFilter(tokenRegistry)
         val basicFilter = BasicAuthenticationSecurityFilter(userAuthenticator)
 
@@ -38,13 +35,9 @@ class RoutingSecurityConfig {
             .csrf().disable()
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
-
-        if (!isAuthOptional) {
-            http.authorizeHttpRequests {
+            .authorizeHttpRequests {
                 it.anyRequest().authenticated()
             }
-        }
-
         return http.build()
     }
 }

--- a/src/main/kotlin/nomic/domain/auth/JWTTokenConfigurationProperties.kt
+++ b/src/main/kotlin/nomic/domain/auth/JWTTokenConfigurationProperties.kt
@@ -4,14 +4,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
  * An object using Spring's configuration properties system to encapsulate configuration settings regarding the RSA keys used for signing JWT tokens
+ * and any other settings relevant to JWTs.
  *
  * @property[signingKeySize] The size of the generated key pair in bits - defaults to 2048. It is not recommended to set below 2048
  * @property[publicKeyPath] The file path and name of the public key, which will be used to persist the key by [FileKeyProvider] - Can be either relative or absolute
  * @property[privateKeyPath] The file path and name of the private key, which will be used to persist the key by [FileKeyProvider] - Can be either relative or absolute
+ * @property[canExpire] Whether the jwt token will ever expire. Defaults to true. It is not recommended to disable this except for development.
  */
 @ConfigurationProperties("token")
 data class JWTTokenConfigurationProperties(
     var signingKeySize: Int = 2048,
     var publicKeyPath: String = "",
-    var privateKeyPath: String = ""
+    var privateKeyPath: String = "",
+    val doesExpire: Boolean? = true
 )

--- a/src/main/kotlin/nomic/domain/auth/TokenRegistry.kt
+++ b/src/main/kotlin/nomic/domain/auth/TokenRegistry.kt
@@ -49,11 +49,13 @@ data class TokenValidationResult(val isSuccess: Boolean, val subject: EndUser? =
  * @see[ITokenRegistry]
  * @param[keyProvider] This dependency is used to retrieve the RSA keys used to sign all JWT Tokens to validate authenticity and integrity
  * @param[usersRepo] This dependency is used to retrieve the user entity that is the subject of valid JWT Tokens
+ * @param[tokenConfig] This dependency is used to retrieve the configured settings for creating and validating JWT Tokens.
  */
 @Service
 class TokenRegistry(
     private val keyProvider: IKeyProvider,
-    private val usersRepo: IUserRepository
+    private val usersRepo: IUserRepository,
+    private val tokenConfig: JWTTokenConfigurationProperties
 ) : ITokenRegistry {
     private val algorithm: Algorithm
     private val verifier: JWTVerifier
@@ -75,8 +77,11 @@ class TokenRegistry(
             .withIssuer(JWT_ISSUER)
             .withAudience(JWT_ISSUER)
             .withIssuedAt(Instant.now())
-            .withExpiresAt(Instant.now().plus(Duration.ofHours(2)))
             .withNotBefore(Instant.now())
+
+        if (tokenConfig.doesExpire != false) {
+            tokenBuilder.withExpiresAt(Instant.now().plus(Duration.ofHours(2)))
+        }
 
         for (claim in claims) {
             tokenBuilder.withClaim(claim.key, claim.value)

--- a/src/test/kotlin/nomic/unit/domain/auth/TokenRegistryTest.kt
+++ b/src/test/kotlin/nomic/unit/domain/auth/TokenRegistryTest.kt
@@ -3,6 +3,7 @@ package nomic.unit.domain.auth
 import com.auth0.jwt.RegisteredClaims
 import nomic.data.repositories.IUserRepository
 import nomic.domain.auth.IKeyProvider
+import nomic.domain.auth.JWTTokenConfigurationProperties
 import nomic.domain.auth.RSAKeyPair
 import nomic.domain.auth.TokenRegistry
 import nomic.domain.entities.EndUser
@@ -32,6 +33,8 @@ class TokenRegistryTest {
 
         val testUser1 = EndUser(512, "Titius Livius")
         val testUser2 = EndUser(1024, "Achilleus")
+
+        val tokenConfig = JWTTokenConfigurationProperties(doesExpire = true)
     }
 
     init {
@@ -57,7 +60,7 @@ class TokenRegistryTest {
 
     @Test
     fun test_issueToken_hasSubjectId() {
-        val tokenRegistry = TokenRegistry(keyProvider, usersRepo)
+        val tokenRegistry = TokenRegistry(keyProvider, usersRepo, tokenConfig)
 
         val token1 = tokenRegistry.issueToken(testUser1)
         val token2 = tokenRegistry.issueToken(testUser2)
@@ -73,7 +76,7 @@ class TokenRegistryTest {
 
     @Test
     fun test_issueToken_hasIssuerAndAudience() {
-        val tokenRegistry = TokenRegistry(keyProvider, usersRepo)
+        val tokenRegistry = TokenRegistry(keyProvider, usersRepo, tokenConfig)
 
         val token = tokenRegistry.issueToken(testUser1)
 
@@ -88,7 +91,7 @@ class TokenRegistryTest {
 
     @Test
     fun test_issueToken_has_issuedAt_expires_notBefore() {
-        val tokenRegistry = TokenRegistry(keyProvider, usersRepo)
+        val tokenRegistry = TokenRegistry(keyProvider, usersRepo, tokenConfig)
 
         val token = tokenRegistry.issueToken(testUser1)
         val tokenBody = String(Base64.getDecoder().decode(token.split('.')[1]))
@@ -100,7 +103,7 @@ class TokenRegistryTest {
 
     @Test
     fun test_issueToken_validates() {
-        val tokenRegistry = TokenRegistry(keyProvider, usersRepo)
+        val tokenRegistry = TokenRegistry(keyProvider, usersRepo, tokenConfig)
 
         val token1 = tokenRegistry.issueToken(testUser1)
         val token2 = tokenRegistry.issueToken(testUser2)
@@ -117,7 +120,7 @@ class TokenRegistryTest {
 
     @Test
     fun test_validateToken_expiredToken() {
-        val tokenRegistry = TokenRegistry(keyProvider, usersRepo)
+        val tokenRegistry = TokenRegistry(keyProvider, usersRepo, tokenConfig)
         val badToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiI1MTIiLCJhdWQiOiJOb21pY0dhbWVNYW5hZ2VyLkFwaSIsIm5iZiI6MTY3ODIyNDYyMCwiaXNzIjoiTm9taWNHYW1lTWFuYWdlci5BcGkiLCJleHAiOjE2NzgyMzE4MjAsImlhdCI6MTY3ODIyNDYyMH0.AzP26ODJH-QEUcaZnRTlIaNMjzIzltOaKPqWf4xW9mSpkJBYCbyoCJGdvU_0kw3E9Ydn9IX_X6ezD29KPmuC8Q"
 
         val result = tokenRegistry.validateToken(badToken)
@@ -128,7 +131,7 @@ class TokenRegistryTest {
 
     @Test
     fun test_validateToken_badToken() {
-        val tokenRegistry = TokenRegistry(keyProvider, usersRepo)
+        val tokenRegistry = TokenRegistry(keyProvider, usersRepo, tokenConfig)
         val result = tokenRegistry.validateToken("Blah.Foo.Bar")
         Assertions.assertThat(result.isSuccess).isFalse
         Assertions.assertThat(result.subject).isNull()


### PR DESCRIPTION
This PR adds a simple toggle which can make authentication optional, so that developing and demoing the app will be easier. If you add `auth.optional=true` to your `secrets.properties`, authentication will not be required on any endpoints, although it will break on the `api/auth/token` endpoint with 500 if you omit valid credentials.

It could be refactored into `ConfigurationProperties` akin to the database config or the token config, but I figured it a simple enough solution to query directly, unless anyone would prefer it to be consistent and more straightforward.

There isn't any documentation for the filterChain, so there aren't any docs to be updated, and the tests don't employ it, so none of those need updating either.